### PR TITLE
Include optional unification dispatch functions for etuples

### DIFF
--- a/etuples/dispatch.py
+++ b/etuples/dispatch.py
@@ -1,10 +1,26 @@
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Sequence, Mapping
 
 from multipledispatch import dispatch
 
 from cons.core import ConsError, ConsNull, ConsPair, car, cdr, cons
 
 from .core import etuple, ExpressionTuple
+
+try:
+    from unification.core import _reify, _unify
+except ModuleNotFoundError:
+    pass
+else:
+
+    def _unify_ExpressionTuple(u, v, s):
+        return _unify(u._tuple, v._tuple, s)
+
+    _unify.add((ExpressionTuple, ExpressionTuple, Mapping), _unify_ExpressionTuple)
+
+    def _reify_ExpressionTuple(u, s):
+        return etuple(*_reify(u._tuple, s))
+
+    _reify.add((ExpressionTuple, Mapping), _reify_ExpressionTuple)
 
 
 @dispatch(object)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -e ./
+unification
 ipython
 coveralls
 pydocstyle>=3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,4 @@ exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:
     assert False
+    ModuleNotFoundError

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,4 +1,4 @@
-from pytest import raises
+from pytest import raises, importorskip
 
 from operator import add
 from collections.abc import Sequence
@@ -91,3 +91,21 @@ def test_etuplize():
 
     assert etuplize(node_2) == etuple(op_1, etuple(op_2, 1, 2), 3)
     assert etuplize(node_2, shallow=True) == etuple(op_1, node_1, 3)
+
+
+def test_unification():
+    from cons import cons
+
+    uni = importorskip("unification")
+
+    var, unify, reify = uni.var, uni.unify, uni.reify
+
+    a_lv, b_lv = var(), var()
+    assert unify(etuple(add, 1, 2), etuple(add, 1, 2), {}) == {}
+    assert unify(etuple(add, 1, 2), etuple(a_lv, 1, 2), {}) == {a_lv: add}
+    assert reify(etuple(a_lv, 1, 2), {a_lv: add}) == etuple(add, 1, 2)
+
+    res = unify(etuple(add, 1, 2), cons(a_lv, b_lv), {})
+    assert res == {a_lv: add, b_lv: etuple(1, 2)}
+
+    assert reify(cons(a_lv, b_lv), res) == etuple(add, 1, 2)


### PR DESCRIPTION
If the `unification` module is present, `ExpressionTuple` dispatch functions for `unify` and `reify` are defined.