### PR TITLE
Allow unification with regular tuples and preserve meta info during reification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e ./
-unification
+logical-unification
 ipython
 coveralls
 pydocstyle>=3.0.0


### PR DESCRIPTION
This PR updates some of the unification/reification behavior.  More specifically, it preserves parent `etuple` information during reification.