### PR TITLE
Prevent etuplize from converting non-expression, nested sequence arguments

### DIFF
--- a/etuples/dispatch.py
+++ b/etuples/dispatch.py
@@ -75,7 +75,7 @@ operator, arguments, term = rator, rands, apply
 
 
 @dispatch(object)
-def etuplize(x, shallow=False, return_bad_args=False):
+def etuplize(x, shallow=False, return_bad_args=False, convert_ConsPairs=True):
     """Return an expression-tuple for an object (i.e. a tuple of rand and rators).
 
     When evaluated, the rand and rators should [re-]construct the object.  When
@@ -95,7 +95,7 @@ def etuplize(x, shallow=False, return_bad_args=False):
     """
     if isinstance(x, ExpressionTuple):
         return x
-    elif x is not None and isinstance(x, (ConsNull, ConsPair)):
+    elif convert_ConsPairs and x is not None and isinstance(x, (ConsNull, ConsPair)):
         return etuple(*x)
 
     try:
@@ -114,7 +114,9 @@ def etuplize(x, shallow=False, return_bad_args=False):
         et_args = args
     else:
         et_op = etuplize(op, return_bad_args=True)
-        et_args = tuple(etuplize(a, return_bad_args=True) for a in args)
+        et_args = tuple(
+            etuplize(a, return_bad_args=True, convert_ConsPairs=False) for a in args
+        )
 
     res = etuple(et_op, *et_args, eval_obj=x)
     return res

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,7 @@ import pytest
 
 from operator import add
 
-from etuples.core import ExpressionTuple, etuple, KwdPair
+from etuples.core import ExpressionTuple, etuple, KwdPair, InvalidExpression
 
 
 def test_ExpressionTuple(capsys):
@@ -40,6 +40,16 @@ def test_ExpressionTuple(capsys):
     ExpressionTuple((print, "hi")).eval_obj
     captured = capsys.readouterr()
     assert captured.out == "hi\n"
+
+    e3 = ExpressionTuple(())
+
+    with pytest.raises(InvalidExpression):
+        e3.eval_obj
+
+    e4 = ExpressionTuple((1,))
+
+    with pytest.raises(InvalidExpression):
+        e4.eval_obj
 
 
 def test_etuple():

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -87,10 +87,11 @@ def test_etuplize():
 
     op_1, op_2 = Operator("*"), Operator("+")
     node_1 = Node(op_2, [1, 2])
-    node_2 = Node(op_1, [node_1, 3])
+    node_2 = Node(op_1, [node_1, 3, ()])
 
-    assert etuplize(node_2) == etuple(op_1, etuple(op_2, 1, 2), 3)
-    assert etuplize(node_2, shallow=True) == etuple(op_1, node_1, 3)
+    assert etuplize(node_2) == etuple(op_1, etuple(op_2, 1, 2), 3, ())
+    assert type(etuplize(node_2)[-1]) == tuple
+    assert etuplize(node_2, shallow=True) == etuple(op_1, node_1, 3, ())
 
 
 def test_unification():


### PR DESCRIPTION
Previously, `etuplize` was converting nested sequence type arguments into `etuple`s.  Doing so can break `etuple` evaluation.