### PR TITLE
Rename eval obj and fix generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ ExpressionTuple((<built-in function add>, 1))
 `etuple`s can also be evaluated:
 
 ```python
->>> et.eval_obj
+>>> et.evaled_obj
 3
 ```
 
 Evaluated `etuple`s are cached:
 ```python
 >>> et = etuple(add, "a", "b")
->>> et.eval_obj
+>>> et.evaled_obj
 'ab'
 
->>> et.eval_obj is et.eval_obj
+>>> et.evaled_obj is et.evaled_obj
 True
 ```
 
@@ -46,7 +46,7 @@ Reconstructed `etuple`s and their evaluation results are preserved across tuple 
 >>> et_new = (et[0],) + et[1:]
 >>> et_new is et
 True
->>> et_new.eval_obj is et.eval_obj
+>>> et_new.evaled_obj is et.evaled_obj
 True
 ```
 
@@ -115,7 +115,7 @@ def apply_Operator(rator, rands):
 >>> pprint(et)
 e(+, e(*, 1, 2), 3)
 
->>> et.eval_obj is add_node
+>>> et.evaled_obj is add_node
 True
 ```
 

--- a/etuples/dispatch.py
+++ b/etuples/dispatch.py
@@ -94,7 +94,7 @@ def apply_Sequence(rator, rands):
 
 @apply.register(Callable, ExpressionTuple)
 def apply_ExpressionTuple(rator, rands):
-    return ((rator,) + rands).eval_obj
+    return ((rator,) + rands).evaled_obj
 
 
 # These are used to maintain some parity with the old `kanren.term` API
@@ -160,6 +160,6 @@ def etuplize(x, shallow=False, return_bad_args=False, convert_ConsPairs=True):
                 )
                 et_args.append(e)
 
-        yield etuple(et_op, *et_args, eval_obj=x)
+        yield etuple(et_op, *et_args, evaled_obj=x)
 
     return trampoline_eval(etuplize_step(x))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 import sys
 from operator import add
+from types import GeneratorType
 
 import pytest
 
@@ -116,6 +117,13 @@ def test_etuple():
     e_ladd = etuple(1, 2) + (3,)
     assert isinstance(e_ladd, ExpressionTuple)
     assert e_ladd == (1, 2, 3)
+
+
+def test_etuple_generator():
+    e_gen = etuple(lambda v: (i for i in v), range(3))
+    e_gen_res = e_gen.evaled_obj
+    assert isinstance(e_gen_res, GeneratorType)
+    assert tuple(e_gen_res) == tuple(range(3))
 
 
 def test_etuple_kwargs():

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -44,17 +44,17 @@ def test_etuple_apply():
     assert apply(add, (1, 2)) == 3
     assert apply(1, (2,)) == (1, 2)
 
-    # Make sure that we don't lose underlying `eval_obj`s
+    # Make sure that we don't lose underlying `evaled_obj`s
     # when taking apart and re-creating expression tuples
     # using `kanren`'s `operator`, `arguments` and `term`
     # functions.
     e1 = etuple(add, (object(),), (object(),))
-    e1_obj = e1.eval_obj
+    e1_obj = e1.evaled_obj
 
     e1_dup = (rator(e1),) + rands(e1)
 
     assert isinstance(e1_dup, ExpressionTuple)
-    assert e1_dup.eval_obj == e1_obj
+    assert e1_dup.evaled_obj == e1_obj
 
     e1_dup_2 = apply(rator(e1), rands(e1))
     assert e1_dup_2 == e1_obj
@@ -128,7 +128,7 @@ def test_unification():
         assert res == {a_lv: 1}
 
     et = etuple(add, 1, 2)
-    assert et.eval_obj == 3
+    assert et.evaled_obj == 3
 
     res = unify(et, cons(a_lv, b_lv))
     assert res == {a_lv: add, b_lv: et[1:]}
@@ -136,7 +136,7 @@ def test_unification():
     # Make sure we've preserved the original object after deconstruction via
     # `unify`
     assert res[b_lv]._parent is et
-    assert ((res[a_lv],) + res[b_lv])._eval_obj == 3
+    assert ((res[a_lv],) + res[b_lv])._evaled_obj == 3
 
     # Make sure we've preserved the original object after reconstruction via
     # `reify`


### PR DESCRIPTION
This PR renames the `ExpressionTuple.eval_obj` property to `ExpressionTuple.evaled_obj` and enables generator evaluation values.