### PR TITLE
Add a method to specify ExpressionTuple evaluation function

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -68,6 +68,22 @@ def test_ExpressionTuple(capsys):
         ExpressionTuple((print, "hi")).eval_obj
 
 
+def test_eval_apply_fn():
+    class Add(object):
+        def __call__(self):
+            return None
+
+        def add(self, x, y):
+            return x + y
+
+    class AddExpressionTuple(ExpressionTuple):
+        def _eval_apply_fn(self, op):
+            return op.add
+
+    op = Add()
+    assert AddExpressionTuple((op, 1, 2)).evaled_obj == 3
+
+
 def test_etuple():
     """Test basic `etuple` functionality."""
 


### PR DESCRIPTION
The goal of #11 was to allow one to customize the way ExpressionTuples are evaluated; however the use of `inspect.signature` and `signature.bind` in `_eval_step` currently prevents `_eval_step` from using custom `_eval_apply`.

Instead of evaluating the ExpressionTuple in the `_eval_apply` method previously introduced, we introduce a `Expression._eval_apply_fn` method that returns the callable used to evaluate the ExpressionTuple. It fulfills the goal of #11 with minimal change to the existing code.